### PR TITLE
Update install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The easiest way to get coca is to use one of the pre-built release binaries whic
 You can also install yourself : 
 
 ```bash
-go get -u github.com/phodal/coca
+go install github.com/phodal/coca@latest
 ```
 
 


### PR DESCRIPTION
```
go get github.com/onsi/ginkgo
go get github.com/onsi/gomega
```
should also be replaced, but running `go install github.com/onsi/ginkgo@latest` pops following error:
```
go: downloading github.com/onsi/ginkgo v1.16.5
package github.com/onsi/ginkgo is not a main package
```
I'm new to golang, so have no idea about how to fix it.