### PR TITLE
fixed #36 完善java测试文件过滤器，增加对测试包路径的判断

### DIFF
--- a/pkg/adapter/cocafile/file_filter.go
+++ b/pkg/adapter/cocafile/file_filter.go
@@ -1,12 +1,16 @@
 package cocafile
 
-import "strings"
+import (
+	"path/filepath"
+	"strings"
+)
 
 var isJavaTestFile = func(path string) bool {
 	return strings.HasSuffix(path, "Test.java") || strings.HasSuffix(path, "Tests.java")
 }
 
 var isJavaTestPackage = func(path string) bool {
+	path = filepath.ToSlash(path)
 	return strings.Contains(path, "src/test/java/")
 }
 

--- a/pkg/adapter/cocafile/file_filter.go
+++ b/pkg/adapter/cocafile/file_filter.go
@@ -2,8 +2,16 @@ package cocafile
 
 import "strings"
 
+var isJavaTestFile = func(path string) bool {
+	return strings.HasSuffix(path, "Test.java") || strings.HasSuffix(path, "Tests.java")
+}
+
+var isJavaTestPackage = func(path string) bool {
+	return strings.Contains(path, "src/test/java/")
+}
+
 var JavaTestFileFilter = func(path string) bool {
-	return strings.Contains(path, "Test.java") || strings.Contains(path, "Tests.java")
+        return isJavaTestFile(path) || isJavaTestPackage(path)
 }
 
 var JavaCodeFileFilter = func(path string) bool {


### PR DESCRIPTION
fixed #36 完善java测试文件过滤器，增加对测试包路径的判断

翻了下代码发现，是有java测试代码过滤逻辑的，但是没有对测试包判断，在测试包下，可能存在一些测试数据mock代码是不带`Test.java`结尾的